### PR TITLE
Mark polyfills as virtual modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { dirname, relative, resolve, join } from "path";
 import { randomBytes } from "crypto";
 import POLYFILLS from './polyfills';
 
-const PREFIX = `polyfill-node:`;
+const PREFIX = `\0polyfill-node:`;
 const PREFIX_LENGTH = PREFIX.length;
 
 export interface NodePolyfillsOptions {


### PR DESCRIPTION
Prepend polyfill module ids by \0 to mark them as virtual modules for `pluginutils` and other plugins, see:
https://rollupjs.org/guide/en/#conventions