### PR TITLE
Comment out unnecessary require "fs"

### DIFF
--- a/scripts/build-polyfills.js
+++ b/scripts/build-polyfills.js
@@ -1,5 +1,5 @@
 const rollup = require('rollup');
-const fs = require('fs');
+// const fs = require('fs');
 const path = require('path');
 const nodeResolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');


### PR DESCRIPTION
the `fs` is unnecessary because where `fs` is used has been commented out.