### PR TITLE
docs: fix readme to remove obsolete note about npm pkg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,6 @@ rollup-plugin-polyfill-node
 
 > This repo is an updated, maintained fork of https://github.com/ionic-team/rollup-plugin-node-polyfills to support better Node.js polyfills in Snowpack and all other Rollup projects. See this thread for discussion on moving this plugin into the official Rollup org: https://github.com/rollup/plugins/pull/51#issuecomment-747489334
 
-> Not yet released, the following npm install command doesn't work yet.
-
 
 ## Quickstart
 


### PR DESCRIPTION
Currently npm pkg is released and usable with npm install