### PR TITLE
fix: 'querystring' missing named exports

### DIFF
--- a/polyfills/qs.js
+++ b/polyfills/qs.js
@@ -144,4 +144,9 @@ export default {
   decode: parse,
   parse: parse
 }
-export {stringify as encode, parse as decode};
+export {
+  stringify as encode,
+  stringify,
+  parse as decode,
+  parse
+};


### PR DESCRIPTION
Adds `stringify`, `parse` to named exports for the `querystring` module.