### PR TITLE
Fix include option behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export interface NodePolyfillsOptions {
 export default function (opts: NodePolyfillsOptions = {}) {
   const mods = getModules();
   const injectPlugin = inject({
-    include: opts.include === undefined ? ['node_modules/**/*.js'] : undefined,
+    include: opts.include === undefined ? ['node_modules/**/*.js'] : opts.include,
     exclude: opts.exclude,
     sourceMap: opts.sourceMap,
     modules: {


### PR DESCRIPTION
Fixes https://github.com/snowpackjs/rollup-plugin-polyfill-node/issues/8 by honoring any `include` options specified by the plugin user.